### PR TITLE
add  .ds-calendar-event {   position: unset !important; } to style

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -287,6 +287,8 @@ body, html, #app, #dayspan {
   height: 100%;
 }
 
+ .ds-calendar-event {   position: unset !important; } 
+ 
 .v-btn--flat,
 .v-text-field--solo .v-input__slot {
   background-color: #f5f5f5 !important;


### PR DESCRIPTION
While I'm not certain that it is the best / appropriate solution, it does address the issue of wrapping the individual day entries.